### PR TITLE
Close connections nicely

### DIFF
--- a/ZenPacks/zenoss/MySqlMonitor/libexec/check_mysql_stats.py
+++ b/ZenPacks/zenoss/MySqlMonitor/libexec/check_mysql_stats.py
@@ -27,6 +27,8 @@ class ZenossMySqlStatsPlugin:
             self.cmd = 'SHOW GLOBAL STATUS'
         else:
             self.cmd = 'SHOW STATUS'
+            
+        self.maxconn = 'select "Max_connections" as "Value",cast(@@global.max_connections as char)'    
 
     def run(self):
         try:
@@ -48,8 +50,19 @@ class ZenossMySqlStatsPlugin:
             print 'Error getting MySQL statistics'
             sys.exit(1)
 
-        print "STATUS OK|%s" % \
-            (' '.join(['='.join(r) for r in cursor.fetchall()]))
+        status_variables = cursor.fetchall()
+
+        ret = cursor.execute(self.maxconn)
+        if not ret:
+            cursor.close()
+            self.conn.close()
+            print 'Error getting MySQL statistics (max_connections)'
+            sys.exit(1)
+
+        status_maxconn = cursor.fetchall()
+
+        print "Status OK|%s %s" %\
+            (' '.join([ '='.join(r) for r in status_variables ]),' '.join([ '='.join(r) for r in status_maxconn ]))
 
         cursor.close()
         self.conn.close()

--- a/ZenPacks/zenoss/MySqlMonitor/libexec/check_mysql_stats.py
+++ b/ZenPacks/zenoss/MySqlMonitor/libexec/check_mysql_stats.py
@@ -44,6 +44,7 @@ class ZenossMySqlStatsPlugin:
         ret = cursor.execute(self.cmd)
         if not ret:
             cursor.close()
+            self.conn.close()
             print 'Error getting MySQL statistics'
             sys.exit(1)
 
@@ -51,6 +52,7 @@ class ZenossMySqlStatsPlugin:
             (' '.join(['='.join(r) for r in cursor.fetchall()]))
 
         cursor.close()
+        self.conn.close()
 
 
 if __name__ == "__main__":

--- a/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
+++ b/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
@@ -1933,6 +1933,15 @@ GAUGE
 True
 </property>
 </object>
+<object id='max_connections' module='Products.ZenModel.RRDDataPoint' class='RRDDataPoint'>
+<property select_variable="rrdtypes" type="selection" id="rrdtype" mode="w" >
+GAUGE
+</property>
+<property type="boolean" id="isrow" mode="w" >
+True
+</property>
+</object>
+
 </tomanycont>
 </object>
 <object id='Replication' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>


### PR DESCRIPTION
We noticed that the "aborted_clients" counter kept rising every time zencommand had run against a mysql server. Apparently there is no nice close() on the connection (only the cursor). 

If adding self.conn.close() after the cursor has been closed, seems to be a nice way to do it.
