### PR TITLE
Provide unique eventKey to each dsplugin class

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -227,6 +227,9 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;3.0.8
+* Give datasources unique eventKeys to avoid false-clearing. (ZPS-500)
+
 ;3.0.7 (2015-11-25)
 * Fix datasources to not block zenpython. (ZEN-19220)
 

--- a/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
@@ -15,7 +15,7 @@ import re
 import time
 import MySQLdb
 
-from twisted.internet import defer, threads
+from twisted.internet import threads
 
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSourcePlugin
@@ -43,7 +43,14 @@ def connection_cursor(ds, ip):
 
 
 class MysqlBasePlugin(PythonDataSourcePlugin):
-    '''Base plugin for MySQL monitoring tasks'''
+    '''
+    Base plugin for MySQL monitoring tasks.
+
+    Note: For onSuccess(), onError(), inner() and eventKey is set to
+          self.__class__.__name__ to avoid cross event clearing.
+          Do not override these 3 methods in child classes without considering
+          this effect.
+    '''
 
     proxy_attributes = (
         'zMySQLConnectionString',
@@ -98,7 +105,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
                     'component': ds.component,
                     'summary': message,
                     'eventClass': '/Status',
-                    'eventKey': 'mysql_result',
+                    'eventKey': self.__class__.__name__,
                     'severity': ds.severity,
                 })
 
@@ -114,7 +121,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
                 'component': component,
                 'summary': 'Monitoring ok',
                 'eventClass': '/Status',
-                'eventKey': 'mysql_result',
+                'eventKey': self.__class__.__name__,
                 'severity': ZenEventClasses.Clear,
             })
         return result
@@ -126,7 +133,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
         data['events'].append({
             'summary': 'error: %s' % result,
             'eventClass': '/Status',
-            'eventKey': 'mysql_result',
+            'eventKey': self.__class__.__name__,
             'severity': ds0.severity,
         })
         return data
@@ -141,7 +148,6 @@ class MySqlMonitorPlugin(MysqlBasePlugin):
 
 
 class MySqlDeadlockPlugin(MysqlBasePlugin):
-
     proxy_attributes = MysqlBasePlugin.proxy_attributes + ('deadlock_info',)
 
     deadlock_time = None

--- a/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
@@ -8,7 +8,6 @@
 #
 ######################################################################
 
-import unittest
 from mock import Mock, patch, sentinel
 
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
@@ -28,7 +27,7 @@ class TestMysqlBasePlugin(BaseTestCase):
 
         event = result['events'][0]
         self.assertEquals(event['severity'], 0)
-        self.assertEquals(event['eventKey'], 'mysql_result')
+        self.assertEquals(event['eventKey'], 'MysqlBasePlugin')
 
     @patch.object(dsplugins, 'log')
     def test_onError_event(self, log):
@@ -39,7 +38,7 @@ class TestMysqlBasePlugin(BaseTestCase):
 
         event = result['events'][0]
         self.assertEquals(event['severity'], 4)
-        self.assertEquals(event['eventKey'], 'mysql_result')
+        self.assertEquals(event['eventKey'], 'MysqlBasePlugin')
         log.error.assertCalledWith(sentinel.some_result)
 
 


### PR DESCRIPTION
Fixes PS-500

* Provide unique key to each dsplugin class to avoid cross-clearing
* Before all plugins were using a generic key, causing false-clears