### PR TITLE
Add eventClassKey for dsplugin class Transforms

### DIFF
--- a/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
+++ b/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
@@ -4004,6 +4004,60 @@ history
 </tomanycont>
 </object>
 </object>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySqlMonitor') -->
+<object id="/zport/dmd/Events/Status/instances/MySqlMonitor" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<property type="string" id="eventClassKey" mode="w">
+MySqlMonitor
+</property>
+<property type="int" id="sequence" mode="w">
+1010
+</property>
+</object>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySqlDeadlock') -->
+<object id="/zport/dmd/Events/Status/instances/MySqlDeadlock" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<property type="string" id="eventClassKey" mode="w">
+MySqlDeadlock
+</property>
+<property type="int" id="sequence" mode="w">
+1010
+</property>
+</object>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySqlReplication') -->
+<object id="/zport/dmd/Events/Status/instances/MySqlReplication" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<property type="string" id="eventClassKey" mode="w">
+MySqlReplication
+</property>
+<property type="int" id="sequence" mode="w">
+1010
+</property>
+</object>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySQLMonitorServers') -->
+<object id="/zport/dmd/Events/Status/instances/MySQLMonitorServers" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<property type="string" id="eventClassKey" mode="w">
+MySQLMonitorServers
+</property>
+<property type="int" id="sequence" mode="w">
+1010
+</property>
+</object>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySQLMonitorDatabases') -->
+<object id="/zport/dmd/Events/Status/instances/MySQLMonitorDatabases" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<property type="string" id="eventClassKey" mode="w">
+MySQLMonitorDatabases
+</property>
+<property type="int" id="sequence" mode="w">
+1010
+</property>
+</object>
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySQLDatabaseExistence') -->
+<object id="/zport/dmd/Events/Status/instances/MySQLDatabaseExistence" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<property type="string" id="eventClassKey" mode="w">
+MySQLDatabaseExistence
+</property>
+<property type="int" id="sequence" mode="w">
+1010
+</property>
+</object>
 <!-- ('', 'zport', 'dmd', 'Manufacturers', 'MySQL') -->
 <object id='/zport/dmd/Manufacturers/MySQL' module='Products.ZenModel.Manufacturer' class='Manufacturer'>
 <property type="string" id="url" mode="w" >

--- a/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
@@ -27,7 +27,7 @@ class TestMysqlBasePlugin(BaseTestCase):
 
         event = result['events'][0]
         self.assertEquals(event['severity'], 0)
-        self.assertEquals(event['eventKey'], 'MysqlBasePlugin')
+        self.assertEquals(event['eventKey'], 'MysqlBase')
 
     @patch.object(dsplugins, 'log')
     def test_onError_event(self, log):
@@ -38,7 +38,7 @@ class TestMysqlBasePlugin(BaseTestCase):
 
         event = result['events'][0]
         self.assertEquals(event['severity'], 4)
-        self.assertEquals(event['eventKey'], 'MysqlBasePlugin')
+        self.assertEquals(event['eventKey'], 'MysqlBase')
         log.error.assertCalledWith(sentinel.some_result)
 
 
@@ -406,7 +406,7 @@ END OF INNODB MONITOR OUTPUT
         events = plugin.query_results_to_events(results, ds)
 
         self.assertEquals(len(events), 2)
-        self.assertEquals(events[1]['eventKey'], 'innodb_deadlock')
+        self.assertEquals(events[1]['eventKey'], 'MySqlDeadlock_innodb')
         self.assertEquals(events[1]['component'], 'component(.)test')
         self.assertEquals(events[1]['severity'], 2)
 
@@ -475,7 +475,7 @@ class TestMySQLDatabaseExistencePlugin(BaseTestCase):
         events = plugin.query_results_to_events(results, ds)
 
         self.assertEquals(len(events), 1)
-        self.assertEquals(events[0]['eventKey'], 'db_test_dropped')
+        self.assertEquals(events[0]['eventKey'], 'MySQLDatabaseExistence_test_dropped')
         self.assertEquals(events[0]['component'], 'test')
         self.assertEquals(events[0]['severity'], 2)
 
@@ -486,9 +486,6 @@ class TestMySQLDatabaseExistencePlugin(BaseTestCase):
         events = plugin.query_results_to_events(results, Mock())
 
         self.assertEquals(len(events), 0)
-        # self.assertEquals(events[0]['eventKey'], 'db_existence')
-        # self.assertEquals(events[0]['component'], sentinel.component)
-        # self.assertEquals(events[0]['severity'], 0)
 
 
 def test_suite():


### PR DESCRIPTION
* Fixes ZPS-934

Customer has requested that evenClassKey's be set for all dsplugin
classes to make event transforms be easier to define. We define in the
base class the eventClassKey (just as for eventKey) which use the python
class name.

* Add eventClassKey to all monitoring plugins
* Refactor dsplugins to unify event handling
* Create associated event mappings
* Adjust unit tests