### PR TITLE
Rework incremental modeling for MySqlMonitor ZP

### DIFF
--- a/ZenPacks/zenoss/MySqlMonitor/MySQLDatabase.py
+++ b/ZenPacks/zenoss/MySqlMonitor/MySQLDatabase.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -95,6 +95,11 @@ class MySQLDatabaseInfo(ComponentInfo):
     @info
     def server(self):
         return self._object.server()
+
+    @property
+    @info
+    def table_count(self):
+        return self._object.cacheRRDValue('table_count')
 
 
 class MySQLDatabasePathReporter(DefaultPathReporter):

--- a/ZenPacks/zenoss/MySqlMonitor/MySQLServer.py
+++ b/ZenPacks/zenoss/MySqlMonitor/MySQLServer.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -53,10 +53,6 @@ class MySQLServer(MySQLComponent):
         ('databases', ToManyCont(
             ToOne, MODULE_NAME['MySQLDatabase'], 'server')),
     )
-
-    def remove(self, object_id=None):
-        if object_id:
-            self.databases._delObject(object_id)
 
     def device(self):
         return self.mysql_host()

--- a/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
@@ -515,13 +515,13 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
         if old_db_config != new_db_config:
             config_diff = list(set(old_db_config) ^ set(new_db_config))
             for db in config_diff:
-                if self.db_configs_by_device:
+                if self.db_configs_by_device.get(ds0.device):
                     if db in new_db_config:
                         data['events'].append(self.produce_event(db, 'added'))
                     else:
                         data['events'].append(self.produce_event(db, 'dropped'))
             log.info('DB configuration has changed, sending new datamaps.')
-            log.info('Diff between DB configs %s', config_diff)
+            log.debug('Difference between DB configs %s', config_diff)
             data['maps'] = maps
         self.db_configs_by_device[ds0.device] = new_db_config
         return data

--- a/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013-2022, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is
@@ -20,7 +20,8 @@ from twisted.internet import threads
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
     import PythonDataSourcePlugin
 from Products.ZenEvents import ZenEventClasses
-from Products.DataCollector.plugins.DataMaps import ObjectMap
+from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
+from Products.ZenUtils.Utils import prepId
 #from ZenPacks.zenoss.PythonCollector import patches
 
 from ZenPacks.zenoss.MySqlMonitor.utils import (
@@ -28,7 +29,21 @@ from ZenPacks.zenoss.MySqlMonitor.utils import (
 from ZenPacks.zenoss.MySqlMonitor import NAME_SPLITTER, MODULE_NAME
 
 
-def connection_cursor(ds, ip):
+def connection_cursor(ds, ip, cursor_type=None):
+    """Returns connection cursor for MySql server.
+
+    :param ds: MySqlMonitor datasource
+    :type ds: datasource
+    :param ip: server ip address (device ip address)
+    :type ip: str
+    :param cursor_type: MySQLdb cursor type, defaults to None
+    :type cursor_type: cursor
+
+    :raises Exception: raises Exception if MySql connection string not configured
+
+    :rtype: cursor
+    :return: cursor on which queries may be performed.
+    """
     if not ds.zMySQLConnectionString:
         raise Exception('MySQL Connection String not configured')
 
@@ -48,7 +63,7 @@ def connection_cursor(ds, ip):
         connect_timeout=getattr(ds, 'zMySqlTimeout', 30)
     )
     db.ping(True)
-    return db.cursor()
+    return db.cursor(cursor_type)
 
 
 class MysqlBasePlugin(PythonDataSourcePlugin):
@@ -74,6 +89,22 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
                    component=None,
                    eventKey=None,
                    eventClassKey=None):
+        """Returns event during MySQL components monitoring.
+
+        :param severity: severity for generated event
+        :type severity: int
+        :param summary: summary for generated event
+        :type summary: str
+        :param component: component id, defaults to None
+        :type component: str
+        :param eventKey: eventKey for generated event, defaults to None
+        :type eventKey: str
+        :param eventClassKey: eventClassKey for generated event, defaults to None
+        :type eventClassKey: str
+
+        :rtype: dict
+        :return: dictionary that represents event for MySql monitored component
+        """
 
         if not eventKey: eventKey = self.keyName
         if not eventClassKey: eventClassKey = self.keyName
@@ -87,18 +118,57 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
         }
 
     def get_query(self, component):
+        """Returns query for MySQL ZP datasource plugin.
+
+        :param component: MySqlMonitor component id
+        :type component: str
+
+        :raises NotImplemented: raises NotImplemented error if not implemented in inherited classes
+
+        :rtype: str
+        :return: query for MySQL ZP datasource plugin
+        """
         raise NotImplemented
 
     def query_results_to_values(self, results):
+        """Returns parsed query results to values for MySqlMonitor components monitoring.
+
+        :param results: raw data structure with monitoring values
+        :type results: tuple
+
+        :rtype: dict
+        :return: dictionary of monitoring values for component
+        """
         return {}
 
     def query_results_to_events(self, results, ds):
+        """Returns parsed query results to events for MySqlMonitor components monitoring.
+
+        :param results: raw data structure with monitoring values
+        :type results: tuple
+        :param ds: MySqlMonitor datasource
+        :type ds: datasource
+
+        :rtype: list
+        :return: list of generated events
+        """
         return []
 
     def query_results_to_maps(self, results, component):
+        """Returns parsed query results to object maps for MySqlMonitor components monitoring.
+
+        :param results: raw data structure with monitoring values
+        :type results: tuple
+        :param component: MySqlMonitor component id
+        :type component: str
+
+        :rtype: list
+        :return: list of collected object maps
+        """
         return []
 
     def inner(self, config):
+        """Returns filled with events, values and maps data structure."""
         # Data structure with empty events, values and maps.
         data = self.new_data()
 
@@ -111,6 +181,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
                 curs = connection_cursor(ds, config.manageIp)
                 curs.execute(self.get_query(ds.component))
                 res = curs.fetchall()
+                curs.close()
                 if res:
                     data['values'][ds.component] = (
                         self.query_results_to_values(res))
@@ -339,6 +410,8 @@ class MySQLMonitorServersPlugin(MysqlBasePlugin):
 
 
 class MySQLMonitorDatabasesPlugin(MysqlBasePlugin):
+    last_table_count_value = {}
+
     def get_query(self, component):
         return '''
         SELECT
@@ -356,24 +429,12 @@ class MySQLMonitorDatabasesPlugin(MysqlBasePlugin):
         fields = enumerate(('table_count', 'size', 'data_size', 'index_size'))
         return dict((f, (results[0][i] or 0)) for i, f in fields)
 
-    def query_results_to_maps(self, results, component):
-        table_count = results[0][0]
-        server = component.split(NAME_SPLITTER)[0]
-        om = ObjectMap({
-            "id": component,
-            "compname": "mysql_servers/%s" % server,
-            "modname": MODULE_NAME['MySQLDatabase'],
-            "relname": "databases",
-            "table_count": table_count,
-            "_add": False
-        })
-        return [om]
-
     def query_results_to_events(self, results, ds):
-        if not ds.table_count:
-            ds.table_count = 0
-
-        diff = results[0][0] - ds.table_count
+        if ds.component not in self.last_table_count_value.keys():
+            self.last_table_count_value[ds.component] = results[0][0]
+            return []
+        diff = results[0][0] - self.last_table_count_value.get(ds.component)
+        self.last_table_count_value[ds.component] = results[0][0]
         if diff == 0:
             return []
 
@@ -385,43 +446,123 @@ class MySQLMonitorDatabasesPlugin(MysqlBasePlugin):
         component = ds.component.split(NAME_SPLITTER)[-1]
         event = self.base_event(severity, summary, component, eventKey=eventKey)
 
-        return[event]
+        return [event]
 
 
-class MySQLDatabaseExistencePlugin(MysqlBasePlugin):
+class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
+    """
+    An Incremental Modeling datasource plugin for MySQL databases
+    """
+
+    db_configs_by_device = {}
+
+    def produce_event(self, db, state):
+        """Returns event after MySQL database addition or deletion.
+
+        :param db: MySQL database ID
+        :type db: str
+        :param state: key word that indicates whether database was added or deleted
+        :type state: str
+
+        :rtype: dict
+        :return: event dict with all filled event fields
+        """
+        db_name = db.split(NAME_SPLITTER)[-1]
+        summary = 'Database "{}" was {}.'.format(db_name, state)
+        eventKey = self.keyName + '_{}_{}'.format(db_name, state)
+        component = db.split(NAME_SPLITTER)[0]
+        event = self.base_event(ZenEventClasses.Info,
+                                summary,
+                                component=component,
+                                eventKey=eventKey)
+
+        return event
+
     def get_query(self, component):
-        return ''' SELECT COUNT(*)
-            FROM information_schema.SCHEMATA
-            WHERE SCHEMA_NAME="%s"
-        ''' % adbapi_safe(
-            component.split(NAME_SPLITTER)[-1]
-        )
+        return """
+        SELECT schema_name title,
+               default_character_set_name,
+               default_collation_name
+        FROM information_schema.schemata;
+        """
 
-    def query_results_to_events(self, results, ds):
-        if not results[0][0]:
-            # Database does not exist, will be deleted
-            db_name = ds.component.split(NAME_SPLITTER)[-1]
-            summary = 'Database "{}" was dropped.'.format(db_name)
-            eventKey = self.keyName + '_{}_dropped'.format(db_name)
-            component = ds.component.split(NAME_SPLITTER)[0]
-            event = self.base_event(ZenEventClasses.Info,
-                                    summary,
-                                    component=component,
-                                    eventKey=eventKey)
+    def inner(self, config):
+        # Data structure with empty events, values and maps.
+        data = self.new_data()
+        ds0 = config.datasources[0]
+        ds0.id = ds0.device
+        results = []
+        for ds in config.datasources:
+            res = {"id": ds.component}
+            try:
+                cursor = connection_cursor(ds, config.manageIp, cursor_type=MySQLdb.cursors.DictCursor)
+                cursor.execute(self.get_query(ds.component))
+                res['db'] = cursor.fetchall()
+                cursor.close()
+            except Exception as e:
+                message = str(e)
+                if ('MySQL server has gone away' in message or
+                        "Can't connect to MySQL server" in message):
+                    message = "Can't connect to MySQL server or timeout error."
+                event = self.base_event(ds.severity, message, ds.component)
+                data['events'].append(event)
+                continue
+            results.append(res)
+        maps = self.get_db_rel_map(results)
+        # get old configuration from previous run
+        old_db_config = self.db_configs_by_device.get(ds0.device) or []
+        new_db_config = self.create_db_config(maps)
+        if old_db_config != new_db_config:
+            config_diff = list(set(old_db_config) ^ set(new_db_config))
+            for db in config_diff:
+                if self.db_configs_by_device:
+                    if db in new_db_config:
+                        data['events'].append(self.produce_event(db, 'added'))
+                    else:
+                        data['events'].append(self.produce_event(db, 'dropped'))
+            log.info('DB configuration has changed, sending new datamaps.')
+            log.info('Diff between DB configs %s', config_diff)
+            data['maps'] = maps
+        self.db_configs_by_device[ds0.device] = new_db_config
+        return data
 
-            return [event]
-        return []
+    @staticmethod
+    def create_db_config(rel_maps):
+        """Returns a list of collected during monitoring MySql database ids.
 
-    def query_results_to_maps(self, results, component):
-        if not results[0][0]:
-            # Database does not exist, will be deleted
-            server = component.split(NAME_SPLITTER)[0]
-            om = ObjectMap({
-                "id": component,
-                "compname": "mysql_servers/%s" % server,
-                "modname": MODULE_NAME['MySQLDatabase'],
-                "relname": "databases",
-                "_remove": True
-            })
-            return [om]
-        return []
+        :param rel_maps: list of MySqlDatabase Relationship Maps
+        :type rel_maps: list
+
+        :rtype: list
+        :return: list of database ids
+        """
+        config = []
+        for rel_map in rel_maps:
+            for obj in getattr(rel_map, 'maps', []):
+                config.append(obj.id)
+        return sorted(config)
+
+    @staticmethod
+    def get_db_rel_map(parsed_query_results):
+        """Returns a list of Relationship Maps for collected MySql database components
+
+        :param parsed_query_results: list of MySql Servers data
+        :type parsed_query_results: list
+
+        :rtype: list
+        :return: list of MySql Databases Relationship Maps
+        """
+        maps = []
+        for server in parsed_query_results:
+            # List of databases
+            db_oms = []
+            for db in server['db']:
+                db_om = ObjectMap(db)
+                db_om.id = prepId(server['id']) + NAME_SPLITTER + prepId(db['title'])
+                db_oms.append(db_om)
+            maps.append(RelationshipMap(
+                compname='mysql_servers/%s' % server['id'],
+                relname='databases',
+                modname=MODULE_NAME['MySQLDatabase'],
+                objmaps=db_oms))
+        return maps

--- a/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
@@ -515,7 +515,7 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
         if old_db_config != new_db_config:
             config_diff = list(set(old_db_config) ^ set(new_db_config))
             for db in config_diff:
-                if self.db_configs_by_device.get(ds0.device):
+                if ds0.device in self.db_configs_by_device.keys():
                     if db in new_db_config:
                         data['events'].append(self.produce_event(db, 'added'))
                     else:

--- a/ZenPacks/zenoss/MySqlMonitor/migrate/DisableDbExistenceDataSource.py
+++ b/ZenPacks/zenoss/MySqlMonitor/migrate/DisableDbExistenceDataSource.py
@@ -1,0 +1,27 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2023, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.ZenModel.ZenPack import ZenPackMigration
+from Products.ZenModel.migrate.Migrate import Version
+
+
+class DisableDbExistenceDataSource(ZenPackMigration):
+    # Main class that contains the migrate() method.
+    # Note version setting.
+    version = Version(3, 2, 0)
+
+    def migrate(self, dmd):
+        # Disable unnecessary DbExistence datasource for MySQL Databases.
+        organizer = dmd.Devices.getOrganizer('/Server')
+        if organizer:
+            for template in organizer.getRRDTemplates():
+                if template.id == 'MySQLDatabase':
+                    for ds in template.getRRDDataSources():
+                        if ds.id == 'DbExistence':
+                            ds.enabled = False

--- a/ZenPacks/zenoss/MySqlMonitor/migrate/RemoveDbExistenceDataSource.py
+++ b/ZenPacks/zenoss/MySqlMonitor/migrate/RemoveDbExistenceDataSource.py
@@ -11,7 +11,7 @@ from Products.ZenModel.ZenPack import ZenPackMigration
 from Products.ZenModel.migrate.Migrate import Version
 
 
-class DisableDbExistenceDataSource(ZenPackMigration):
+class RemoveDbExistenceDataSource(ZenPackMigration):
     # Main class that contains the migrate() method.
     # Note version setting.
     version = Version(3, 2, 0)
@@ -22,6 +22,4 @@ class DisableDbExistenceDataSource(ZenPackMigration):
         if organizer:
             for template in organizer.getRRDTemplates():
                 if template.id == 'MySQLDatabase':
-                    for ds in template.getRRDDataSources():
-                        if ds.id == 'DbExistence':
-                            ds.enabled = False
+                    template.manage_deleteRRDDataSources(('DbExistence',))

--- a/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
+++ b/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
@@ -1220,26 +1220,26 @@ AVERAGE
 ZenPacks.zenoss.MySqlMonitor.MySQLDatabase
 </property>
 <tomanycont id='datasources'>
-<object id='DbExistence' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>
-<property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
-Python
-</property>
-<property type="boolean" id="enabled" mode="w" >
-True
-</property>
-<property type="string" id="component" mode="w" >
-${here/id}
-</property>
-<property type="int" id="severity" mode="w" >
-4
-</property>
-<property type="string" id="cycletime" mode="w" >
-300
-</property>
-<property type="string" id="plugin_classname" mode="w" >
-ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLDatabaseExistencePlugin
-</property>
-</object>
+<!--<object id='DbExistence' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>-->
+<!--<property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >-->
+<!--Python-->
+<!--</property>-->
+<!--<property type="boolean" id="enabled" mode="w" >-->
+<!--True-->
+<!--</property>-->
+<!--<property type="string" id="component" mode="w" >-->
+<!--${here/id}-->
+<!--</property>-->
+<!--<property type="int" id="severity" mode="w" >-->
+<!--4-->
+<!--</property>-->
+<!--<property type="string" id="cycletime" mode="w" >-->
+<!--300-->
+<!--</property>-->
+<!--<property type="string" id="plugin_classname" mode="w" >-->
+<!--ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLDatabaseExistencePlugin-->
+<!--</property>-->
+<!--</object>-->
 <object id='DbStats' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>
 <property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
 Python
@@ -1261,6 +1261,14 @@ ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLMonitorDatabasesPlugin
 </property>
 <tomanycont id='datapoints'>
 <object id='data_size' module='Products.ZenModel.RRDDataPoint' class='RRDDataPoint'>
+<property select_variable="rrdtypes" type="selection" id="rrdtype" mode="w" >
+GAUGE
+</property>
+<property type="boolean" id="isrow" mode="w" >
+True
+</property>
+</object>
+<object id='table_count' module='Products.ZenModel.RRDDataPoint' class='RRDDataPoint'>
 <property select_variable="rrdtypes" type="selection" id="rrdtype" mode="w" >
 GAUGE
 </property>
@@ -1420,6 +1428,26 @@ AVERAGE
 ZenPacks.zenoss.MySqlMonitor.MySQLServer
 </property>
 <tomanycont id='datasources'>
+<object id='DbIncrementalModeling' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>
+<property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
+Python
+</property>
+<property type="boolean" id="enabled" mode="w" >
+True
+</property>
+<property type="string" id="component" mode="w" >
+${here/id}
+</property>
+<property type="int" id="severity" mode="w" >
+4
+</property>
+<property type="string" id="cycletime" mode="w" >
+300
+</property>
+<property type="string" id="plugin_classname" mode="w" >
+ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLDatabaseIncrementalModelingPlugin
+</property>
+</object>
 <object id='DbStats' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>
 <property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
 Python
@@ -4049,10 +4077,10 @@ MySQLMonitorDatabases
 1010
 </property>
 </object>
-<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySQLDatabaseExistence') -->
-<object id="/zport/dmd/Events/Status/instances/MySQLDatabaseExistence" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
+<!-- ('', 'zport', 'dmd', 'Events', 'Status', 'instances', 'MySQLDatabaseIncrementalModeling') -->
+<object id="/zport/dmd/Events/Status/instances/MySQLDatabaseIncrementalModeling" module="Products.ZenEvents.EventClassInst" class="EventClassInst">
 <property type="string" id="eventClassKey" mode="w">
-MySQLDatabaseExistence
+MySQLDatabaseIncrementalModeling
 </property>
 <property type="int" id="sequence" mode="w">
 1010

--- a/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
+++ b/ZenPacks/zenoss/MySqlMonitor/objects/objects.xml
@@ -1220,26 +1220,6 @@ AVERAGE
 ZenPacks.zenoss.MySqlMonitor.MySQLDatabase
 </property>
 <tomanycont id='datasources'>
-<!--<object id='DbExistence' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>-->
-<!--<property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >-->
-<!--Python-->
-<!--</property>-->
-<!--<property type="boolean" id="enabled" mode="w" >-->
-<!--True-->
-<!--</property>-->
-<!--<property type="string" id="component" mode="w" >-->
-<!--${here/id}-->
-<!--</property>-->
-<!--<property type="int" id="severity" mode="w" >-->
-<!--4-->
-<!--</property>-->
-<!--<property type="string" id="cycletime" mode="w" >-->
-<!--300-->
-<!--</property>-->
-<!--<property type="string" id="plugin_classname" mode="w" >-->
-<!--ZenPacks.zenoss.MySqlMonitor.dsplugins.MySQLDatabaseExistencePlugin-->
-<!--</property>-->
-<!--</object>-->
 <object id='DbStats' module='ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource' class='PythonDataSource'>
 <property select_variable="sourcetypes" type="selection" id="sourcetype" mode="w" >
 Python

--- a/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
@@ -1,31 +1,33 @@
 ######################################################################
 #
-# Copyright (C) Zenoss, Inc. 2013, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2013-2023, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is
 # installed.
 #
 ######################################################################
-
-from mock import Mock, patch, sentinel
+import time
+from mock import Mock, patch, sentinel, MagicMock
 
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from Products.DataCollector.plugins.DataMaps import RelationshipMap, ObjectMap
 
 from ZenPacks.zenoss.MySqlMonitor import NAME_SPLITTER
 from ZenPacks.zenoss.MySqlMonitor import dsplugins
 
 
 class TestMysqlBasePlugin(BaseTestCase):
-    def setUp(self):
+    def afterSetUp(self):
         self.plugin = dsplugins.MysqlBasePlugin()
+        self.config = Mock()
+        self.ds = Mock()
 
     def test_onSuccess_clears_event(self):
         result = {'events': [], 'values': {"test": "test"}}
-        config = ds = Mock()
-        ds.severity = 4
-        config.datasources = [ds]
-        self.plugin.onSuccess(result, config)
+        self.ds.severity = 4
+        self.config.datasources = [self.ds]
+        self.plugin.onSuccess(result, self.config)
 
         event = result['events'][0]
         self.assertEquals(event['severity'], 0)
@@ -33,41 +35,75 @@ class TestMysqlBasePlugin(BaseTestCase):
 
     @patch.object(dsplugins, 'log')
     def test_onError_event(self, log):
-        config = ds = Mock()
-        ds.severity = 4
-        config.datasources = [ds]
-        result = self.plugin.onError(sentinel.some_result, config)
+        self.ds.severity = 4
+        self.config.datasources = [self.ds]
+        result = self.plugin.onError(sentinel.some_result, self.config)
 
         event = result['events'][0]
         self.assertEquals(event['severity'], 4)
         self.assertEquals(event['eventKey'], 'MysqlBase')
         log.error.assertCalledWith(sentinel.some_result)
 
+    def test_base_event(self):
+        self.ds.component = 'test_component'
+        event = self.plugin.base_event(4, 'summary', self.ds.component)
+        self.assertEquals(event['severity'], 4)
+        self.assertEquals(event['eventKey'], 'MysqlBase')
+        self.assertEquals(event['eventClassKey'], 'MysqlBase')
+        self.assertEquals(event['component'], 'test_component')
+        self.assertEquals(event['summary'], 'summary')
+
 
 class TestMySqlMonitorPlugin(BaseTestCase):
+    def afterSetUp(self):
+        self.plugin = dsplugins.MySqlMonitorPlugin()
 
     def test_results_to_values(self):
         results = (
             ('Value', sentinel.value),
         )
-
-        plugin = dsplugins.MySqlMonitorPlugin()
-        values = plugin.query_results_to_values(results)
-
+        values = self.plugin.query_results_to_values(results)
         self.assertEquals(values, {
             'value': (sentinel.value, 'N')
         })
 
     def test_empty_results_to_values(self):
         results = ()
-
-        plugin = dsplugins.MySqlMonitorPlugin()
-        values = plugin.query_results_to_values(results)
-
+        values = self.plugin.query_results_to_values(results)
         self.assertEquals(values, {})
 
 
 class TestMySqlDeadlockPlugin(BaseTestCase):
+    def afterSetUp(self):
+        self.plugin = dsplugins.MySqlDeadlockPlugin()
+        self.ds = Mock()
+
+    def test_event(self):
+        event = self.plugin._event(4, 'summary', self.ds.component)
+        self.assertEquals(event['severity'], 4)
+        self.assertEquals(event['eventKey'], 'MySqlDeadlock_innodb')
+        self.assertEquals(event['eventClassKey'], 'MySqlDeadlock')
+        self.assertEquals(event['summary'], 'summary')
+
+    def test_query_results_to_maps_no_clear_time(self):
+        self.plugin.deadlock_evt_clear_time = None
+        results = None
+        component = self.ds.component
+        maps = self.plugin.query_results_to_maps(results, component)
+        self.assertEquals(len(maps), 0)
+
+    def test_query_results_to_maps(self):
+        component = 'test_db'
+        self.plugin.deadlock_evt_clear_time = time.time()
+        self.plugin.deadlock_time = time.time()
+        self.plugin.deadlock_db = component
+        results = None
+        maps = self.plugin.query_results_to_maps(results, component)
+        self.assertEquals(len(maps), 1)
+        self.assertEquals(maps[0].id, 'test_db')
+        self.assertEquals(len(maps[0].deadlock_info), 3)
+        self.assertEquals(maps[0].relname, 'mysql_servers')
+        self.assertEquals(maps[0].modname, 'ZenPacks.zenoss.MySqlMonitor.MySQLServer')
 
     def test_query_status_ok_to_events(self):
         results = (
@@ -246,13 +282,11 @@ Number of rows inserted 22379, updated 5922, deleted 18763, read 341468
 ----------------------------
 END OF INNODB MONITOR OUTPUT
 ============================
-'''), )
+'''),)
 
-        plugin = dsplugins.MySqlDeadlockPlugin()
-        ds = Mock()
-        ds.deadlock_info = None
-        ds.component = sentinel.component
-        events = plugin.query_results_to_events(results, ds)
+        self.ds.deadlock_info = None
+        self.ds.component = sentinel.component
+        events = self.plugin.query_results_to_events(results, self.ds)
         self.assertEquals(len(events), 0)
 
     def test_query_status_deadlock_to_events(self):
@@ -399,13 +433,11 @@ Number of rows inserted 2, updated 0, deleted 0, read 6
 ----------------------------
 END OF INNODB MONITOR OUTPUT
 ============================
-'''), )
+'''),)
 
-        plugin = dsplugins.MySqlDeadlockPlugin()
-        ds = Mock()
-        ds.deadlock_info = None
-        ds.component = 'component'
-        events = plugin.query_results_to_events(results, ds)
+        self.ds.deadlock_info = None
+        self.ds.component = 'component'
+        events = self.plugin.query_results_to_events(results, self.ds)
 
         self.assertEquals(len(events), 2)
         self.assertEquals(events[1]['eventKey'], 'MySqlDeadlock_innodb')
@@ -413,14 +445,85 @@ END OF INNODB MONITOR OUTPUT
         self.assertEquals(events[1]['severity'], 2)
 
 
+class TestMySqlReplicationPlugin(BaseTestCase):
+    def afterSetUp(self):
+        self.plugin = dsplugins.MySqlReplicationPlugin()
+        self.ds = Mock()
+
+    def test_event(self):
+        event = self.plugin._event(4, 'summary', self.ds.component, 'io')
+        self.assertEquals(event['severity'], 4)
+        self.assertEquals(event['eventKey'], 'MySqlReplication_io')
+        self.assertEquals(event['eventClassKey'], 'MySqlReplication')
+        self.assertEquals(event['summary'], 'summary')
+
+    def test_query_results_to_events_no_results(self):
+        events = self.plugin.query_results_to_events(None, self.ds)
+        self.assertEquals(len(events), 0)
+
+    def test_query_results_to_events_slave_io(self):
+        results = (tuple('Yes' if i == 10 else None for i in xrange(20)),)
+        events = self.plugin.query_results_to_events(results, self.ds)
+        self.assertEquals(len(events), 5)
+        self.assertEquals(events[0]['severity'], 0)
+        self.assertEquals(events[0]['summary'], "Slave IO Running")
+        self.assertEquals(events[0]['eventKey'], "MySqlReplication_io")
+        self.assertEquals(events[1]['severity'], 4)
+        self.assertEquals(events[1]['summary'], "Slave SQL NOT Running")
+        self.assertEquals(events[1]['eventKey'], "MySqlReplication_sql")
+        self.assertEquals(events[2]['severity'], 0)
+        self.assertEquals(events[2]['summary'], "No replication error")
+        self.assertEquals(events[2]['eventKey'], "MySqlReplication_err")
+        self.assertEquals(events[3]['severity'], 0)
+        self.assertEquals(events[3]['summary'], "No replication IO error")
+        self.assertEquals(events[3]['eventKey'], "MySqlReplication_ioe")
+        self.assertEquals(events[4]['severity'], 0)
+        self.assertEquals(events[4]['summary'], "No replication SQL error")
+        self.assertEquals(events[4]['eventKey'], "MySqlReplication_se")
+
+    def test_query_results_to_events_slave_sql(self):
+        results = (tuple('Yes' if i == 11 else None for i in xrange(20)),)
+        events = self.plugin.query_results_to_events(results, self.ds)
+        self.assertEquals(len(events), 5)
+        self.assertEquals(events[1]['severity'], 0)
+        self.assertEquals(events[1]['summary'], "Slave SQL Running")
+        self.assertEquals(events[1]['eventKey'], "MySqlReplication_sql")
+        self.assertEquals(events[0]['severity'], 4)
+        self.assertEquals(events[0]['summary'], "Slave IO NOT Running")
+        self.assertEquals(events[0]['eventKey'], "MySqlReplication_io")
+        self.assertEquals(events[2]['severity'], 0)
+        self.assertEquals(events[2]['summary'], "No replication error")
+        self.assertEquals(events[2]['eventKey'], "MySqlReplication_err")
+        self.assertEquals(events[3]['severity'], 0)
+        self.assertEquals(events[3]['summary'], "No replication IO error")
+        self.assertEquals(events[3]['eventKey'], "MySqlReplication_ioe")
+        self.assertEquals(events[4]['severity'], 0)
+        self.assertEquals(events[4]['summary'], "No replication SQL error")
+        self.assertEquals(events[4]['eventKey'], "MySqlReplication_se")
+
+    def test_query_results_to_events_err_strings(self):
+        results = (tuple('error_string' if i in [19, 35, 37] else None for i in xrange(38)),)
+        events = self.plugin.query_results_to_events(results, self.ds)
+        self.assertEquals(len(events), 5)
+        self.assertEquals(events[2]['severity'], 4)
+        self.assertEquals(events[2]['summary'], "error_string")
+        self.assertEquals(events[2]['eventKey'], "MySqlReplication_err")
+        self.assertEquals(events[3]['severity'], 4)
+        self.assertEquals(events[3]['summary'], "error_string")
+        self.assertEquals(events[3]['eventKey'], "MySqlReplication_ioe")
+        self.assertEquals(events[4]['severity'], 4)
+        self.assertEquals(events[4]['summary'], "error_string")
+        self.assertEquals(events[4]['eventKey'], "MySqlReplication_se")
+
+
 class TestMySQLMonitorDatabasesPlugin(BaseTestCase):
+    def afterSetUp(self):
+        self.plugin = dsplugins.MySQLMonitorDatabasesPlugin()
+        self.ds = Mock()
 
     def test_no_results_to_values(self):
         results = ((0, None, None, None),)
-
-        plugin = dsplugins.MySQLMonitorDatabasesPlugin()
-        values = plugin.query_results_to_values(results)
-
+        values = self.plugin.query_results_to_values(results)
         self.assertEquals(values, dict(
             (k, (0))
             for k in ('table_count', 'size', 'data_size', 'index_size')
@@ -428,15 +531,12 @@ class TestMySQLMonitorDatabasesPlugin(BaseTestCase):
 
     def test_results_to_values(self):
         results = ((
-            sentinel.table_count,
-            sentinel.size,
-            sentinel.data_size,
-            sentinel.index_size,
-        ),)
-
-        plugin = dsplugins.MySQLMonitorDatabasesPlugin()
-        values = plugin.query_results_to_values(results)
-
+                       sentinel.table_count,
+                       sentinel.size,
+                       sentinel.data_size,
+                       sentinel.index_size,
+                   ),)
+        values = self.plugin.query_results_to_values(results)
         self.assertEquals(values, dict(
             table_count=(sentinel.table_count),
             size=(sentinel.size),
@@ -444,50 +544,206 @@ class TestMySQLMonitorDatabasesPlugin(BaseTestCase):
             index_size=(sentinel.index_size),
         ))
 
-    def test_tables_number_event(self):
+    def test_tables_count_event_first_run(self):
         results = ((4, 1, 1, 1),)
-        plugin = dsplugins.MySQLMonitorDatabasesPlugin()
-
         ds = Mock()
         ds.component = "test" + NAME_SPLITTER + "test"
-        ds.table_count = None
-        events = plugin.query_results_to_events(results, ds)
+        events = self.plugin.query_results_to_events(results, ds)
+        self.assertEquals(len(events), 0)
+        self.assertEquals(self.plugin.last_table_count_value[ds.component], 4)
+
+    def test_tables_count_event_table_addition(self):
+        results = ((4, 1, 1, 1),)
+        self.ds.component = "test" + NAME_SPLITTER + "test"
+
+        self.plugin.last_table_count_value[self.ds.component] = 0
+        events = self.plugin.query_results_to_events(results, self.ds)
         self.assertEquals(len(events), 1)
         self.assertEquals(events[0]['summary'], '4 tables were added.')
         self.assertEquals(events[0]['severity'], 2)
+        self.assertEquals(self.plugin.last_table_count_value[self.ds.component], 4)
 
-        ds.table_count = 3
-        events = plugin.query_results_to_events(results, ds)
+        self.plugin.last_table_count_value[self.ds.component] = 3
+        events = self.plugin.query_results_to_events(results, self.ds)
+        self.assertEquals(len(events), 1)
         self.assertEquals(events[0]['summary'], '1 table was added.')
         self.assertEquals(events[0]['severity'], 2)
+        self.assertEquals(self.plugin.last_table_count_value[self.ds.component], 4)
 
-        ds.table_count = 5
-        events = plugin.query_results_to_events(results, ds)
+    def test_tables_count_event_table_deletion(self):
+        results = ((1, 1, 1, 1),)
+        self.ds.component = "test" + NAME_SPLITTER + "test"
+
+        self.plugin.last_table_count_value[self.ds.component] = 4
+        events = self.plugin.query_results_to_events(results, self.ds)
+        self.assertEquals(len(events), 1)
+        self.assertEquals(events[0]['summary'], '3 tables were dropped.')
+        self.assertEquals(events[0]['severity'], 3)
+        self.assertEquals(self.plugin.last_table_count_value[self.ds.component], 1)
+
+        self.plugin.last_table_count_value[self.ds.component] = 2
+        events = self.plugin.query_results_to_events(results, self.ds)
+        self.assertEquals(len(events), 1)
         self.assertEquals(events[0]['summary'], '1 table was dropped.')
         self.assertEquals(events[0]['severity'], 3)
+        self.assertEquals(self.plugin.last_table_count_value[self.ds.component], 1)
 
 
-class TestMySQLDatabaseExistencePlugin(BaseTestCase):
-    def test_db_not_exists(self):
-        results = ((0,),)
-        ds = Mock()
-        ds.component = "test" + NAME_SPLITTER + "test"
+class TestMySQLMonitorServersPlugin(BaseTestCase):
+    def afterSetUp(self):
+        self.plugin = dsplugins.MySQLMonitorServersPlugin()
+        self.ds = Mock()
 
-        plugin = dsplugins.MySQLDatabaseExistencePlugin()
-        events = plugin.query_results_to_events(results, ds)
+    def test_query_results_to_values(self):
+        results = ((1, 1, 1, 1),)
+        expected_result = {
+            'table_count': 1,
+            'size': 1,
+            'data_size': 1,
+            'index_size': 1
+        }
+        observed_result = self.plugin.query_results_to_values(results)
+        self.assertEquals(observed_result, expected_result)
 
-        self.assertEquals(len(events), 1)
-        self.assertEquals(events[0]['eventKey'], 'MySQLDatabaseExistence_test_dropped')
-        self.assertEquals(events[0]['component'], 'test')
-        self.assertEquals(events[0]['severity'], 2)
 
-    def test_db_exists(self):
-        results = ((1,),)
+class TestMySQLDatabaseIncrementalModelingPlugin(BaseTestCase):
+    def afterSetUp(self):
+        self.plugin = dsplugins.MySQLDatabaseIncrementalModelingPlugin()
+        self.ds = Mock()
+        self.cursor = MagicMock()
+        self.config = Mock(manageIp='ip_address')
 
-        plugin = dsplugins.MySQLDatabaseExistencePlugin()
-        events = plugin.query_results_to_events(results, Mock())
+    def test_produce_dropped_event(self):
+        event = self.plugin.produce_event('test_server(.)test_db', 'dropped')
+        self.assertEquals(event['summary'], 'Database "test_db" was dropped.')
+        self.assertEquals(event['eventKey'], 'MySQLDatabaseIncrementalModeling_test_db_dropped')
+        self.assertEquals(event['component'], 'test_server')
+        self.assertEquals(event['severity'], 2)
 
-        self.assertEquals(len(events), 0)
+    def test_produce_added_event(self):
+        event = self.plugin.produce_event('test_server(.)test_db', 'added')
+        self.assertEquals(event['summary'], 'Database "test_db" was added.')
+        self.assertEquals(event['eventKey'], 'MySQLDatabaseIncrementalModeling_test_db_added')
+        self.assertEquals(event['component'], 'test_server')
+        self.assertEquals(event['severity'], 2)
+
+    def test_create_db_config(self):
+        rel_maps = []
+        db_oms = [
+            {
+                'id': 'test_server(.)test_db_1'
+            },
+            {
+                'id': 'test_server(.)test_db_2'
+            },
+            {
+                'id': 'test_server(.)test_db_3'
+            },
+        ]
+        rel_maps.append(RelationshipMap(
+            compname='mysql_servers/test_server',
+            relname='databases',
+            modname='ZenPacks.zenoss.MySqlMonitor.MySQLDatabase',
+            objmaps=db_oms))
+        config = self.plugin.create_db_config(rel_maps)
+        self.assertEquals(len(config), 3)
+        self.assertEquals(config[0], 'test_server(.)test_db_1')
+        self.assertEquals(config[1], 'test_server(.)test_db_2')
+        self.assertEquals(config[2], 'test_server(.)test_db_3')
+
+    def test_get_db_rel_map(self):
+        parsed_query_results = [
+            {
+                'id': 'test_server_1',
+                'db':
+                    [
+                        {
+                            'title': 'test_db_1'
+                        },
+                        {
+                            'title': 'test_db_2'
+                        },
+                        {
+                            'title': 'test_db_3'
+                        }
+                    ]
+            },
+            {
+                'id': 'test_server_2',
+                'db':
+                    [
+                        {
+                            'title': 'test_db_1'
+                        },
+                        {
+                            'title': 'test_db_2'
+                        },
+                        {
+                            'title': 'test_db_3'
+                        }
+                    ]
+            }
+
+        ]
+        maps = self.plugin.get_db_rel_map(parsed_query_results)
+        self.assertEquals(len(maps), 2)
+        self.assertEquals(maps[0].relname, 'databases')
+        self.assertEquals(maps[0].compname, 'mysql_servers/test_server_1')
+        self.assertEquals(maps[0].maps[0].modname, 'ZenPacks.zenoss.MySqlMonitor.MySQLDatabase')
+        self.assertEquals(maps[0].maps[0].id, 'test_server_1(.)test_db_1')
+
+    @patch('ZenPacks.zenoss.MySqlMonitor.dsplugins.connection_cursor')
+    def test_inner_empty_config(self, connection_cursor):
+        expected_db_config = {'mysql_host': ['test_server(.)test_db_1', 'test_server(.)test_db_2']}
+        self.config.datasources = [MagicMock(component='test_server',
+                                             severity=2,
+                                             device='mysql_host')]
+
+        connection_cursor.return_value = self.cursor
+        self.cursor.fetchall.return_value = [{'title': 'test_db_1'}, {'title': 'test_db_2'}]
+        data = self.plugin.inner(self.config)
+        rel_map = data['maps'][0]
+        self.assertEquals(self.plugin.db_configs_by_device, expected_db_config)
+        self.assertEquals(rel_map.relname, 'databases')
+        self.assertEquals(rel_map.compname, 'mysql_servers/test_server')
+        self.assertEquals(len(rel_map.maps), 2)
+        self.assertEquals(rel_map.maps[0].modname, 'ZenPacks.zenoss.MySqlMonitor.MySQLDatabase')
+        self.assertEquals(rel_map.maps[0].id, 'test_server(.)test_db_1')
+
+    @patch('ZenPacks.zenoss.MySqlMonitor.dsplugins.connection_cursor')
+    def test_inner_delete_db(self, connection_cursor):
+        self.plugin.db_configs_by_device = {'mysql_host': ['test_server(.)test_db_1', 'test_server(.)test_db_2']}
+        expected_db_config = {'mysql_host': []}
+        self.config.datasources = [MagicMock(component='test_server',
+                                             severity=2,
+                                             device='mysql_host')]
+
+        connection_cursor.return_value = self.cursor
+        self.cursor.fetchall.return_value = []
+        data = self.plugin.inner(self.config)
+        rel_map = data['maps'][0]
+        events = data['events']
+        self.assertEquals(self.plugin.db_configs_by_device, expected_db_config)
+        self.assertEquals(len(rel_map.maps), 0)
+        self.assertEquals(len(events), 2)
+
+    @patch('ZenPacks.zenoss.MySqlMonitor.dsplugins.connection_cursor')
+    def test_inner_add_db(self, connection_cursor):
+        self.plugin.db_configs_by_device = {'mysql_host': []}
+        expected_db_config = {'mysql_host': ['test_server(.)test_db_1',
+                                             'test_server(.)test_db_2',
+                                             'test_server(.)test_db_3']}
+        self.config.datasources = [MagicMock(component='test_server',
+                                             severity=2,
+                                             device='mysql_host')]
+        connection_cursor.return_value = self.cursor
+        self.cursor.fetchall.return_value = [{'title': 'test_db_1'}, {'title': 'test_db_2'}, {'title': 'test_db_3'}]
+        data = self.plugin.inner(self.config)
+        rel_map = data['maps'][0]
+        events = data['events']
+        self.assertEquals(self.plugin.db_configs_by_device, expected_db_config)
+        self.assertEquals(len(rel_map.maps), 3)
+        self.assertEquals(len(events), 3)
 
 
 def test_suite():
@@ -497,5 +753,7 @@ def test_suite():
     suite.addTest(makeSuite(TestMySqlMonitorPlugin))
     suite.addTest(makeSuite(TestMySqlDeadlockPlugin))
     suite.addTest(makeSuite(TestMySQLMonitorDatabasesPlugin))
-    suite.addTest(makeSuite(TestMySQLDatabaseExistencePlugin))
+    suite.addTest(makeSuite(TestMySqlReplicationPlugin))
+    suite.addTest(makeSuite(TestMySQLMonitorServersPlugin))
+    suite.addTest(makeSuite(TestMySQLDatabaseIncrementalModelingPlugin))
     return suite


### PR DESCRIPTION
Fixes ZPS-6799.

Added MySQLDatabaseIncrementalModelingPlugin datasource plugin and DbIncrementalModeling datasource for MySql databases incremental modeling. Datasource adds/deletes MySql databases and updates primary information according to changes in the appropriate MySql server. Removed broken MySQLDatabaseExistencePlugin datasource plugin. Added migration file for broken DbExistence datasource disabling. Moved table_count property from object map attribute to datapoint. Deleted unused imports and methods.
Added appropriate unit tests.