### PR TITLE
Fix event class setting for MySql datasources

### DIFF
--- a/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
@@ -204,7 +204,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
                         "Can't connect to MySQL server" in message):
                     message = "Can't connect to MySQL server or timeout error."
 
-                event = self.base_event(ds.severity, message, ds.component)
+                event = self.base_event(ds.severity, message, ds.component, eventClass=ds.eventClass)
                 data['events'].append(event)
 
         return data
@@ -217,7 +217,8 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
             # Clear events for success components.
             event = self.base_event(ZenEventClasses.Clear,
                                     'Monitoring ok',
-                                    ds.component)
+                                    ds.component,
+                                    eventClass=ds.eventClass)
             result['events'].insert(0, event)
         return result
 
@@ -226,7 +227,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
         ds0 = config.datasources[0]
         data = self.new_data()
         summary = 'error: {}'.format(result)
-        event = self.base_event(ds0.severity, summary)
+        event = self.base_event(ds0.severity, summary, eventClass=ds0.eventClass)
         data['events'].append(event)
         return data
 
@@ -251,9 +252,9 @@ class MySqlDeadlockPlugin(MysqlBasePlugin):
         re.M | re.DOTALL
     )
 
-    def _event(self, severity, summary, component, ds):
+    def _event(self, severity, summary, component, eventClass):
         event_key = self.keyName + '_innodb'
-        return self.base_event(severity, summary, component, eventKey=event_key, eventClass=ds.eventClass)
+        return self.base_event(severity, summary, component, eventKey=event_key, eventClass=eventClass)
 
     def get_query(self, component):
         return 'show engine innodb status'
@@ -276,7 +277,7 @@ class MySqlDeadlockPlugin(MysqlBasePlugin):
             dl_time, dl_db, evt_clear_time = ds.deadlock_info
 
             if evt_clear_time and time.time() > evt_clear_time:
-                events.append(self._event(ZenEventClasses.Clear, 'Ok', dl_db, ds))
+                events.append(self._event(ZenEventClasses.Clear, 'Ok', dl_db, ds.eventClass))
         else:
             dl_time = dl_db = evt_clear_time = None
 
@@ -306,10 +307,10 @@ class MySqlDeadlockPlugin(MysqlBasePlugin):
                     self.deadlock_evt_clear_time = time.time() + 60*30
                     # Clear a previous event
                     events.append(self._event(
-                        ZenEventClasses.Clear, 'Ok', dl_db, ds))
+                        ZenEventClasses.Clear, 'Ok', dl_db, ds.eventClass))
                     # Create a new event
                     events.append(self._event(
-                        ZenEventClasses.Info, summary, component, ds))
+                        ZenEventClasses.Info, summary, component, ds.eventClass))
 
         return events
 
@@ -331,9 +332,9 @@ class MySqlReplicationPlugin(MysqlBasePlugin):
     def get_query(self, component):
         return 'show slave status'
 
-    def _event(self, severity, summary, ds, suffix):
+    def _event(self, severity, summary,  component, eventClass, suffix):
         eventKey = self.keyName + '_' + suffix
-        return self.base_event(severity, summary, ds.component, eventKey=eventKey, eventClass=ds.eventClass)
+        return self.base_event(severity, summary, component, eventKey=eventKey, eventClass=eventClass)
 
     def query_results_to_events(self, results, ds):
         if not results:
@@ -365,32 +366,34 @@ class MySqlReplicationPlugin(MysqlBasePlugin):
             last_sql_err_no = results[0][36]
             last_sql_err_str = results[0][37]
 
+        c = ds.component
+        eventClass = ds.eventClass
         events = []
 
         if slave_io == "Yes":
-            events.append(self._event(0, "Slave IO Running", ds, "io"))
+            events.append(self._event(0, "Slave IO Running", c, eventClass, "io"))
         else:
-            events.append(self._event(4, "Slave IO NOT Running", ds, "io"))
+            events.append(self._event(4, "Slave IO NOT Running", c, eventClass, "io"))
 
         if slave_sql == "Yes":
-            events.append(self._event(0, "Slave SQL Running", ds, "sql"))
+            events.append(self._event(0, "Slave SQL Running", c, eventClass, "sql"))
         else:
-            events.append(self._event(4, "Slave SQL NOT Running", ds, "sql"))
+            events.append(self._event(4, "Slave SQL NOT Running", c, eventClass, "sql"))
 
         if last_err_str:
-            events.append(self._event(4, last_err_str, ds, "err"))
+            events.append(self._event(4, last_err_str, c, eventClass, "err"))
         else:
-            events.append(self._event(0, "No replication error", ds, "err"))
+            events.append(self._event(0, "No replication error", c, eventClass, "err"))
 
         if last_io_err_str:
-            events.append(self._event(4, last_io_err_str, ds, "ioe"))
+            events.append(self._event(4, last_io_err_str, c, eventClass, "ioe"))
         else:
-            events.append(self._event(0, "No replication IO error", ds, "ioe"))
+            events.append(self._event(0, "No replication IO error", c, eventClass, "ioe"))
 
         if last_sql_err_str:
-            events.append(self._event(4, last_sql_err_str, ds, "se"))
+            events.append(self._event(4, last_sql_err_str, c, eventClass, "se"))
         else:
-            events.append(self._event(0, "No replication SQL error", ds, "se"))
+            events.append(self._event(0, "No replication SQL error", c, eventClass, "se"))
 
         return events
 
@@ -459,7 +462,7 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
 
     db_configs_by_device = {}
 
-    def produce_event(self, db, ds0, state):
+    def produce_event(self, db, eventClass, state):
         """Returns event after MySQL database addition or deletion.
 
         :param db: MySQL database ID
@@ -481,7 +484,7 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
                                 summary,
                                 component=component,
                                 eventKey=eventKey,
-                                eventClass=ds0.eventClass)
+                                eventClass=eventClass)
 
         return event
 
@@ -524,9 +527,9 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
             for db in config_diff:
                 if ds0.device in self.db_configs_by_device.keys():
                     if db in new_db_config:
-                        data['events'].append(self.produce_event(db, ds0, 'added'))
+                        data['events'].append(self.produce_event(db, ds0.eventClass, 'added'))
                     else:
-                        data['events'].append(self.produce_event(db, ds0, 'dropped'))
+                        data['events'].append(self.produce_event(db, ds0.eventClass, 'dropped'))
             log.info('DB configuration has changed, sending new datamaps.')
             log.debug('Difference between DB configs %s', config_diff)
             data['maps'] = maps

--- a/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/dsplugins.py
@@ -88,7 +88,8 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
                    summary,
                    component=None,
                    eventKey=None,
-                   eventClassKey=None):
+                   eventClassKey=None,
+                   eventClass=None):
         """Returns event during MySQL components monitoring.
 
         :param severity: severity for generated event
@@ -101,6 +102,8 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
         :type eventKey: str
         :param eventClassKey: eventClassKey for generated event, defaults to None
         :type eventClassKey: str
+        :param eventClass: eventClass for generated event, defaults to None
+        :type eventClass: str
 
         :rtype: dict
         :return: dictionary that represents event for MySql monitored component
@@ -115,6 +118,7 @@ class MysqlBasePlugin(PythonDataSourcePlugin):
             'component': component,
             'eventKey': eventKey,
             'eventClassKey': eventClassKey,
+            'eventClass': eventClass
         }
 
     def get_query(self, component):
@@ -247,9 +251,9 @@ class MySqlDeadlockPlugin(MysqlBasePlugin):
         re.M | re.DOTALL
     )
 
-    def _event(self, severity, summary, component):
+    def _event(self, severity, summary, component, ds):
         event_key = self.keyName + '_innodb'
-        return self.base_event(severity, summary, component, eventKey=event_key)
+        return self.base_event(severity, summary, component, eventKey=event_key, eventClass=ds.eventClass)
 
     def get_query(self, component):
         return 'show engine innodb status'
@@ -272,7 +276,7 @@ class MySqlDeadlockPlugin(MysqlBasePlugin):
             dl_time, dl_db, evt_clear_time = ds.deadlock_info
 
             if evt_clear_time and time.time() > evt_clear_time:
-                events.append(self._event(ZenEventClasses.Clear, 'Ok', dl_db))
+                events.append(self._event(ZenEventClasses.Clear, 'Ok', dl_db, ds))
         else:
             dl_time = dl_db = evt_clear_time = None
 
@@ -302,10 +306,10 @@ class MySqlDeadlockPlugin(MysqlBasePlugin):
                     self.deadlock_evt_clear_time = time.time() + 60*30
                     # Clear a previous event
                     events.append(self._event(
-                        ZenEventClasses.Clear, 'Ok', dl_db))
+                        ZenEventClasses.Clear, 'Ok', dl_db, ds))
                     # Create a new event
                     events.append(self._event(
-                        ZenEventClasses.Info, summary, component))
+                        ZenEventClasses.Info, summary, component, ds))
 
         return events
 
@@ -327,9 +331,9 @@ class MySqlReplicationPlugin(MysqlBasePlugin):
     def get_query(self, component):
         return 'show slave status'
 
-    def _event(self, severity, summary, component, suffix):
+    def _event(self, severity, summary, ds, suffix):
         eventKey = self.keyName + '_' + suffix
-        return self.base_event(severity, summary, component, eventKey=eventKey)
+        return self.base_event(severity, summary, ds.component, eventKey=eventKey, eventClass=ds.eventClass)
 
     def query_results_to_events(self, results, ds):
         if not results:
@@ -361,33 +365,32 @@ class MySqlReplicationPlugin(MysqlBasePlugin):
             last_sql_err_no = results[0][36]
             last_sql_err_str = results[0][37]
 
-        c = ds.component
         events = []
 
         if slave_io == "Yes":
-            events.append(self._event(0, "Slave IO Running", c, "io"))
+            events.append(self._event(0, "Slave IO Running", ds, "io"))
         else:
-            events.append(self._event(4, "Slave IO NOT Running", c, "io"))
+            events.append(self._event(4, "Slave IO NOT Running", ds, "io"))
 
         if slave_sql == "Yes":
-            events.append(self._event(0, "Slave SQL Running", c, "sql"))
+            events.append(self._event(0, "Slave SQL Running", ds, "sql"))
         else:
-            events.append(self._event(4, "Slave SQL NOT Running", c, "sql"))
+            events.append(self._event(4, "Slave SQL NOT Running", ds, "sql"))
 
         if last_err_str:
-            events.append(self._event(4, last_err_str, c, "err"))
+            events.append(self._event(4, last_err_str, ds, "err"))
         else:
-            events.append(self._event(0, "No replication error", c, "err"))
+            events.append(self._event(0, "No replication error", ds, "err"))
 
         if last_io_err_str:
-            events.append(self._event(4, last_io_err_str, c, "ioe"))
+            events.append(self._event(4, last_io_err_str, ds, "ioe"))
         else:
-            events.append(self._event(0, "No replication IO error", c, "ioe"))
+            events.append(self._event(0, "No replication IO error", ds, "ioe"))
 
         if last_sql_err_str:
-            events.append(self._event(4, last_sql_err_str, c, "se"))
+            events.append(self._event(4, last_sql_err_str, ds, "se"))
         else:
-            events.append(self._event(0, "No replication SQL error", c, "se"))
+            events.append(self._event(0, "No replication SQL error", ds, "se"))
 
         return events
 
@@ -444,7 +447,7 @@ class MySQLMonitorDatabasesPlugin(MysqlBasePlugin):
 
         eventKey = 'table_count{}'.format(str(time.time()))
         component = ds.component.split(NAME_SPLITTER)[-1]
-        event = self.base_event(severity, summary, component, eventKey=eventKey)
+        event = self.base_event(severity, summary, component, eventKey=eventKey, eventClass=ds.eventClass)
 
         return [event]
 
@@ -456,13 +459,16 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
 
     db_configs_by_device = {}
 
-    def produce_event(self, db, state):
+    def produce_event(self, db, ds0, state):
         """Returns event after MySQL database addition or deletion.
 
         :param db: MySQL database ID
         :type db: str
+        :param ds0: DbIncrementalModeling Datasource
+        :type ds0: datasource
         :param state: key word that indicates whether database was added or deleted
         :type state: str
+
 
         :rtype: dict
         :return: event dict with all filled event fields
@@ -474,7 +480,8 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
         event = self.base_event(ZenEventClasses.Info,
                                 summary,
                                 component=component,
-                                eventKey=eventKey)
+                                eventKey=eventKey,
+                                eventClass=ds0.eventClass)
 
         return event
 
@@ -517,9 +524,9 @@ class MySQLDatabaseIncrementalModelingPlugin(MysqlBasePlugin):
             for db in config_diff:
                 if ds0.device in self.db_configs_by_device.keys():
                     if db in new_db_config:
-                        data['events'].append(self.produce_event(db, 'added'))
+                        data['events'].append(self.produce_event(db, ds0, 'added'))
                     else:
-                        data['events'].append(self.produce_event(db, 'dropped'))
+                        data['events'].append(self.produce_event(db, ds0, 'dropped'))
             log.info('DB configuration has changed, sending new datamaps.')
             log.debug('Difference between DB configs %s', config_diff)
             data['maps'] = maps

--- a/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
@@ -80,8 +80,7 @@ class TestMySqlDeadlockPlugin(BaseTestCase):
         self.ds = Mock()
 
     def test_event(self):
-        self.ds.configure_mock(eventClass='/Status')
-        event = self.plugin._event(4, 'summary', self.ds.component, self.ds)
+        event = self.plugin._event(4, 'summary', self.ds.component, '/Status')
         self.assertEquals(event['severity'], 4)
         self.assertEquals(event['eventKey'], 'MySqlDeadlock_innodb')
         self.assertEquals(event['eventClassKey'], 'MySqlDeadlock')
@@ -454,11 +453,12 @@ class TestMySqlReplicationPlugin(BaseTestCase):
         self.ds = Mock()
 
     def test_event(self):
-        event = self.plugin._event(4, 'summary', self.ds.component, 'io')
+        event = self.plugin._event(4, 'summary', self.ds.component, '/Status', 'io')
         self.assertEquals(event['severity'], 4)
         self.assertEquals(event['eventKey'], 'MySqlReplication_io')
         self.assertEquals(event['eventClassKey'], 'MySqlReplication')
         self.assertEquals(event['summary'], 'summary')
+        self.assertEquals(event['eventClass'], '/Status')
 
     def test_query_results_to_events_no_results(self):
         events = self.plugin.query_results_to_events(None, self.ds)
@@ -617,8 +617,7 @@ class TestMySQLDatabaseIncrementalModelingPlugin(BaseTestCase):
         self.config = Mock(manageIp='ip_address')
 
     def test_produce_dropped_event(self):
-        self.ds.configure_mock(eventClass='/Status/SQL')
-        event = self.plugin.produce_event('test_server(.)test_db', self.ds, 'dropped')
+        event = self.plugin.produce_event('test_server(.)test_db', '/Status/SQL', 'dropped')
         self.assertEquals(event['summary'], 'Database "test_db" was dropped.')
         self.assertEquals(event['eventKey'], 'MySQLDatabaseIncrementalModeling_test_db_dropped')
         self.assertEquals(event['component'], 'test_server')
@@ -626,8 +625,7 @@ class TestMySQLDatabaseIncrementalModelingPlugin(BaseTestCase):
         self.assertEquals(event['eventClass'], '/Status/SQL')
 
     def test_produce_added_event(self):
-        self.ds.configure_mock(eventClass='/Status')
-        event = self.plugin.produce_event('test_server(.)test_db', self.ds, 'added')
+        event = self.plugin.produce_event('test_server(.)test_db', '/Status', 'added')
         self.assertEquals(event['summary'], 'Database "test_db" was added.')
         self.assertEquals(event['eventKey'], 'MySQLDatabaseIncrementalModeling_test_db_added')
         self.assertEquals(event['component'], 'test_server')

--- a/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
+++ b/ZenPacks/zenoss/MySqlMonitor/tests/test_dsplugins.py
@@ -46,12 +46,13 @@ class TestMysqlBasePlugin(BaseTestCase):
 
     def test_base_event(self):
         self.ds.component = 'test_component'
-        event = self.plugin.base_event(4, 'summary', self.ds.component)
+        event = self.plugin.base_event(4, 'summary', self.ds.component, eventClass='/Status')
         self.assertEquals(event['severity'], 4)
         self.assertEquals(event['eventKey'], 'MysqlBase')
         self.assertEquals(event['eventClassKey'], 'MysqlBase')
         self.assertEquals(event['component'], 'test_component')
         self.assertEquals(event['summary'], 'summary')
+        self.assertEquals(event['eventClass'], '/Status')
 
 
 class TestMySqlMonitorPlugin(BaseTestCase):
@@ -79,11 +80,13 @@ class TestMySqlDeadlockPlugin(BaseTestCase):
         self.ds = Mock()
 
     def test_event(self):
-        event = self.plugin._event(4, 'summary', self.ds.component)
+        self.ds.configure_mock(eventClass='/Status')
+        event = self.plugin._event(4, 'summary', self.ds.component, self.ds)
         self.assertEquals(event['severity'], 4)
         self.assertEquals(event['eventKey'], 'MySqlDeadlock_innodb')
         self.assertEquals(event['eventClassKey'], 'MySqlDeadlock')
         self.assertEquals(event['summary'], 'summary')
+        self.assertEquals(event['eventClass'], '/Status')
 
     def test_query_results_to_maps_no_clear_time(self):
         self.plugin.deadlock_evt_clear_time = None
@@ -614,18 +617,22 @@ class TestMySQLDatabaseIncrementalModelingPlugin(BaseTestCase):
         self.config = Mock(manageIp='ip_address')
 
     def test_produce_dropped_event(self):
-        event = self.plugin.produce_event('test_server(.)test_db', 'dropped')
+        self.ds.configure_mock(eventClass='/Status/SQL')
+        event = self.plugin.produce_event('test_server(.)test_db', self.ds, 'dropped')
         self.assertEquals(event['summary'], 'Database "test_db" was dropped.')
         self.assertEquals(event['eventKey'], 'MySQLDatabaseIncrementalModeling_test_db_dropped')
         self.assertEquals(event['component'], 'test_server')
         self.assertEquals(event['severity'], 2)
+        self.assertEquals(event['eventClass'], '/Status/SQL')
 
     def test_produce_added_event(self):
-        event = self.plugin.produce_event('test_server(.)test_db', 'added')
+        self.ds.configure_mock(eventClass='/Status')
+        event = self.plugin.produce_event('test_server(.)test_db', self.ds, 'added')
         self.assertEquals(event['summary'], 'Database "test_db" was added.')
         self.assertEquals(event['eventKey'], 'MySQLDatabaseIncrementalModeling_test_db_added')
         self.assertEquals(event['component'], 'test_server')
         self.assertEquals(event['severity'], 2)
+        self.assertEquals(event['eventClass'], '/Status')
 
     def test_create_db_config(self):
         rel_maps = []


### PR DESCRIPTION
Fixes ZPS-5766.

Added eventClass attribute to the base_event method. 
All the datasources that produce events now send their eventClass. 
Fixed appropriate unit tests.