### PR TITLE
Fix database's properties appearance on the UI

### DIFF
--- a/ZenPacks/zenoss/MySqlMonitor/modeler/plugins/MySQLCollector.py
+++ b/ZenPacks/zenoss/MySqlMonitor/modeler/plugins/MySQLCollector.py
@@ -131,6 +131,7 @@ class MySQLCollector(PythonPlugin):
             # List of databases
             db_oms = []
             for db in server['db']:
+                db = {k.lower(): v for k, v in db.items()}
                 d_om = ObjectMap(db)
                 d_om.id = s_om.id + NAME_SPLITTER + self.prepId(db['title'])
                 db_oms.append(d_om)


### PR DESCRIPTION
Fixes ZPS-8559.

MySQL Server 8.x Default Character Set and Default Collation keys are returned in uppercase. 
The fix makes all the keys in the output lowercase.